### PR TITLE
Move project_name into cluster specific vars

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,4 +1,3 @@
-project_name: lifecycle
 project_admin_role: admin
 project_editor_role: edit
 project_viewer_role: view
@@ -16,3 +15,4 @@ registry_api_secret_name: registry-api
 stage_api_secret_name: stage-api
 prod_api_secret_name: prod-api
 notify_email_list: aweiteka@redhat.com
+oc: oc --token={{ token }} --server=https://{{ clusterhost }} -n {{ project_name }}

--- a/ansible/host_vars/dev.example
+++ b/ansible/host_vars/dev.example
@@ -1,6 +1,6 @@
+project_name: dev
 clusterhost: dev.example.com:8443
 token: eyJhbGciOiJSUzI1...qKqF-hefeU06alfBaQ
-oc: oc --insecure-skip-tls-verify=true --token={{ token }} --server=https://{{ clusterhost }}
 
 admin_users:
   - user1

--- a/ansible/host_vars/prod.example
+++ b/ansible/host_vars/prod.example
@@ -1,6 +1,6 @@
+project_name: prod
 clusterhost: prod.example.com
 token: eyJhbGciOiJSUzI1...U-qgyCo9XLtEpWUkpG3CEmmg
-oc: oc --token={{ token }} --server=https://{{ clusterhost }}
 
 admin_users:
   - user1@example.com

--- a/ansible/host_vars/registry.example
+++ b/ansible/host_vars/registry.example
@@ -1,6 +1,6 @@
+project_name: registry
 clusterhost: registry.example.com:8443
 token: eyJhbGciOiJSUzI1...q6vB3PLizZIMmnA
-oc: oc --insecure-skip-tls-verify=true --token={{ token }} --server=https://{{ clusterhost }}
 
 admin_users:
 editor_users:

--- a/ansible/host_vars/stage.example
+++ b/ansible/host_vars/stage.example
@@ -1,6 +1,6 @@
+project_name: stage
 clusterhost: stage.example.com:8443
 token: eyJhbGciOiJSUzI1N...uopaWYtJZeyI68td5acu6eg59bQ5A8eI08xQ
-oc: oc --insecure-skip-tls-verify=true --token={{ token }} --server=https://{{ clusterhost }}
 
 jenkins_automation_openshift_role: edit
 

--- a/ansible/roles/auth/tasks/main.yml
+++ b/ansible/roles/auth/tasks/main.yml
@@ -1,47 +1,47 @@
 ---
 - name: Add admin users
-  command: "{{ oc }} policy add-role-to-user {{ project_admin_role}} {{ item }} -n {{ project_name }}"
+  command: "{{ oc }} policy add-role-to-user {{ project_admin_role}} {{ item }}"
   with_items: "{{ admin_users }}"
   when: admin_users
 - name: Add editor users
-  command: "{{ oc }} policy add-role-to-user {{ project_editor_role}} {{ item }} -n {{ project_name }}"
+  command: "{{ oc }} policy add-role-to-user {{ project_editor_role}} {{ item }}"
   with_items: "{{ editor_users }}"
   when: editor_users
 - name: Add viewer users
-  command: "{{ oc }} policy add-role-to-user {{ project_registry_viewer_role}} {{ item }} -n {{ project_name }}"
+  command: "{{ oc }} policy add-role-to-user {{ project_registry_viewer_role}} {{ item }}"
   with_items: "{{ viewer_users }}"
   when: viewer_users
 
 - name: Remove admin users
-  command: "{{ oc }} policy remove-role-from-user {{ project_admin_role}} {{ item }} -n {{ project_name }}"
+  command: "{{ oc }} policy remove-role-from-user {{ project_admin_role}} {{ item }}"
   with_items: "{{ deprecated_admin_users }}"
   when: deprecated_admin_users
 - name: Remove editor users
-  command: "{{ oc }} policy remove-role-from-user {{ project_editor_role}} {{ item }} -n {{ project_name }}"
+  command: "{{ oc }} policy remove-role-from-user {{ project_editor_role}} {{ item }}"
   with_items: "{{ deprecated_editor_users }}"
   when: deprecated_editor_users
 - name: Remove viewer users
-  command: "{{ oc }} policy remove-role-from-user {{ project_registry_viewer_role}} {{ item }} -n {{ project_name }}"
+  command: "{{ oc }} policy remove-role-from-user {{ project_registry_viewer_role}} {{ item }}"
   with_items: "{{ deprecated_viewer_users }}"
   when: deprecated_viewer_users
 
 - name: Check if Jenkins serviceaccount exists
-  command: "{{ oc }} get sa {{ jenkins_serviceaccount_name }} -n {{ project_name }}"
+  command: "{{ oc }} get sa {{ jenkins_serviceaccount_name }}"
   register: jenkins_sa_exists
   ignore_errors: true
   when: jenkins_automation_openshift_role is defined
 - name: Create Jenkins serviceaccount
-  command: "{{ oc }} create serviceaccount {{ jenkins_serviceaccount_name }} -n {{ project_name }}"
+  command: "{{ oc }} create serviceaccount {{ jenkins_serviceaccount_name }}"
   when:
     - jenkins_sa_exists|failed
     - jenkins_automation_openshift_role is defined
 - name: Assign role to Jenkins serviceaccount
-  command: "{{ oc }} policy add-role-to-user {{ jenkins_automation_openshift_role }} system:serviceaccount:{{ project_name }}:{{ jenkins_serviceaccount_name }} -n {{ project_name }}"
+  command: "{{ oc }} policy add-role-to-user {{ jenkins_automation_openshift_role }} system:serviceaccount:{{ project_name }}:{{ jenkins_serviceaccount_name }}"
   when:
     - jenkins_sa_exists|failed
     - jenkins_automation_openshift_role is defined
 - name: Get Jenkins token value
-  command: "{{ oc }} sa get-token {{ jenkins_serviceaccount_name }} -n {{ project_name }}"
+  command: "{{ oc }} sa get-token {{ jenkins_serviceaccount_name }}"
   register: jenkinstoken
   when: jenkins_automation_openshift_role is defined
 - set_fact:
@@ -49,10 +49,10 @@
   when: jenkins_automation_openshift_role is defined
 
 - name: Get registry push token value
-  command: "{{ oc }} sa get-token builder -n {{ project_name }}"
+  command: "{{ oc }} sa get-token builder"
   register: forpush
 - name: Get pull token value
-  command: "{{ oc }} sa get-token deployer -n {{ project_name }}"
+  command: "{{ oc }} sa get-token deployer"
   register: forpull
 - set_fact:
     pushtoken: "{{ forpush.stdout }}"

--- a/ansible/roles/jenkins/tasks/main.yml
+++ b/ansible/roles/jenkins/tasks/main.yml
@@ -1,41 +1,41 @@
 - name: Check if {{ registry_api_secret_name }} exists
-  command: "{{ oc }} get secret {{ registry_api_secret_name }} -n {{ project_name }}"
+  command: "{{ oc }} get secret {{ registry_api_secret_name }}"
   when: registry_api_secret_name is defined
   register: registry_api_secret_exists
   ignore_errors: true
 - name: Check if {{ stage_api_secret_name }} exists
-  command: "{{ oc }} get secret {{ stage_api_secret_name }} -n {{ project_name }}"
+  command: "{{ oc }} get secret {{ stage_api_secret_name }}"
   when: stage_api_secret_name is defined
   register: stage_api_secret_exists
   ignore_errors: true
 - name: Check if {{ prod_api_secret_name }} exists
-  command: "{{ oc }} get secret {{ prod_api_secret_name }} -n {{ project_name }}"
+  command: "{{ oc }} get secret {{ prod_api_secret_name }}"
   when: prod_api_secret_name is defined
   register: prod_api_secret_exists
   ignore_errors: true
 - name: Create secret {{ registry_api_secret_name }}
-  command: "{{ oc }} secret new-basicauth {{ registry_api_secret_name }} --password {{ hostvars['registry']['jenkinstoken'] }} -n {{ project_name }}"
+  command: "{{ oc }} secret new-basicauth {{ registry_api_secret_name }} --password {{ hostvars['registry']['jenkinstoken'] }}"
   when:
     - registry_api_secret_exists|failed
     - hostvars['registry']['jenkinstoken'] is defined
 - name: Create secret {{ stage_api_secret_name }}
-  command: "{{ oc }} secret new-basicauth {{ stage_api_secret_name }} --password {{ hostvars['stage']['jenkinstoken'] }} -n {{ project_name }}"
+  command: "{{ oc }} secret new-basicauth {{ stage_api_secret_name }} --password {{ hostvars['stage']['jenkinstoken'] }}"
   when:
     - stage_api_secret_exists|failed
     - hostvars['stage']['jenkinstoken'] is defined
 - name: Create secret {{ prod_api_secret_name }}
-  command: "{{ oc }} secret new-basicauth {{ prod_api_secret_name }} --password {{ hostvars['prod']['jenkinstoken'] }} -n {{ project_name }}"
+  command: "{{ oc }} secret new-basicauth {{ prod_api_secret_name }} --password {{ hostvars['prod']['jenkinstoken'] }}"
   when:
     - prod_api_secret_exists|failed
     - hostvars['prod']['jenkinstoken'] is defined
 - name: Create custom Jenkins source-to-image build
-  shell: "{{ oc }} process -f {{ role_path }}/files/jenkins-custom-build.yaml -n {{ project_name }} | {{ oc }} apply --force=true -f - -n {{ project_name }}"
+  shell: "{{ oc }} process -f {{ role_path }}/files/jenkins-custom-build.yaml | {{ oc }} apply --force=true -f -"
 - name: Create Jenkins app
-  shell: "{{ oc }} process -f {{ role_path }}/files/jenkins-master.yaml --param NAMESPACE={{ project_name }} --param VOLUME_CAPACITY={{ jenkins_volume_size }} --param MEMORY_LIMIT=2Gi --param JENKINS_IMAGE_STREAM_TAG=jenkins-custom:latest -n {{ project_name }} | {{ oc }} apply -f - -n {{ project_name }}"
+  shell: "{{ oc }} process -f {{ role_path }}/files/jenkins-master.yaml --param NAMESPACE={{ project_name }} --param VOLUME_CAPACITY={{ jenkins_volume_size }} --param MEMORY_LIMIT=2Gi --param JENKINS_IMAGE_STREAM_TAG=jenkins-custom:latest | {{ oc }} apply -f -"
 - name: Create application pipeline
-  shell: "{{ oc }} process -f {{ role_path }}/files/app-pipeline.yaml -n {{ project_name }} | {{ oc }} apply --force=true -f - -n {{ project_name }}"
+  shell: "{{ oc }} process -f {{ role_path }}/files/app-pipeline.yaml | {{ oc }} apply --force=true -f -"
 - name: Create release pipeline
-  shell: "{{ oc }} process -f {{ role_path }}/files/release-pipeline.yaml -n {{ project_name }}
+  shell: "{{ oc }} process -f {{ role_path }}/files/release-pipeline.yaml
     -p SOURCE_REPOSITORY_URL={{ source_repo_url }}
     -p SOURCE_REPOSITORY_REF={{ source_repo_branch }}
     -p IMAGE_STREAM_NAME={{ imagestream_name }}
@@ -49,11 +49,11 @@
     -p REGISTRY_SECRET_NAME={{ registry_api_secret_name }}
     -p NOTIFY_EMAIL_LIST={{ notify_email_list }} | {{ oc }} apply --force=true -f - -n {{ project_name }}"
 - name: Create Jenkins master pipeline
-  shell: "{{ oc }} process -f {{ role_path }}/files/jenkins-pipeline.yaml -n {{ project_name }} | {{ oc }} apply --force=true -f - -n {{ project_name }}"
+  shell: "{{ oc }} process -f {{ role_path }}/files/jenkins-pipeline.yaml | {{ oc }} apply --force=true -f -"
 - name: Create application base image pipeline
-  shell: "{{ oc }} process -f {{ role_path }}/files/base-image-pipeline.yaml --param BASE_IMAGE_TAG='nodejs:6' --param APP_BC='nodejs-mongo-persistent' --param APP_NAME='nodejs-mongo-persistent' --param EMAIL_LIST='aweiteka@redhat.com jcallen@redhat.com' --param=APP_PIPELINE='lifecycle-app-lifecycle' -n {{ project_name }} | {{ oc }} apply --force=true -f - -n {{ project_name }}"
+  shell: "{{ oc }} process -f {{ role_path }}/files/base-image-pipeline.yaml --param BASE_IMAGE_TAG='nodejs:6' --param APP_BC='nodejs-mongo-persistent' --param APP_NAME='nodejs-mongo-persistent' --param EMAIL_LIST='aweiteka@redhat.com jcallen@redhat.com' --param=APP_PIPELINE='lifecycle-app-lifecycle' | {{ oc }} apply --force=true -f -"
 - name: Create Jenkins base image pipeline
-  shell: "{{ oc }} process -f {{ role_path }}/files/base-image-pipeline.yaml -n {{ project_name }} | {{ oc }} apply --force=true -f - -n {{ project_name }}"
+  shell: "{{ oc }} process -f {{ role_path }}/files/base-image-pipeline.yaml | {{ oc }} apply --force=true -f -"
 - name: Get last jenkins-custom build number
   command: "{{ oc }} get bc jenkins-custom --template '{{ '{{' }} .status.lastVersion {{ '}}' }}'"
   register: jenkins_custom_build_number

--- a/ansible/roles/puller/tasks/main.yml
+++ b/ansible/roles/puller/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Check if pull central registry secret exists
-  command: "{{ oc }} get secret pull-external-registry -n {{ project_name }}"
+  command: "{{ oc }} get secret pull-external-registry"
   register: pull_registry_secret
   ignore_errors: true
 - name: Docker pull registry secret
-  command: "{{ oc }} secrets new-dockercfg pull-external-registry --docker-username=unused --docker-password={{ hostvars['registry']['pulltoken'] }} --docker-email=unused --docker-server={{ central_registry_hostname }} -n {{ project_name }}"
+  command: "{{ oc }} secrets new-dockercfg pull-external-registry --docker-username=unused --docker-password={{ hostvars['registry']['pulltoken'] }} --docker-email=unused --docker-server={{ central_registry_hostname }}"
   when: pull_registry_secret|failed
 - name: Link docker pull registry secret
-  command: "{{ oc }} secrets link default pull-external-registry --for=pull -n {{ project_name }}"
+  command: "{{ oc }} secrets link default pull-external-registry --for=pull"
   when: pull_registry_secret|failed

--- a/ansible/roles/pusher/tasks/main.yml
+++ b/ansible/roles/pusher/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Check if push central registry secret exists
-  command: "{{ oc }} get secret push-external-registry -n {{ project_name }}"
+  command: "{{ oc }} get secret push-external-registry"
   register: central_registry_secret
   ignore_errors: true
 - name: Docker push central registry secret
-  command: "{{ oc }} secrets new-dockercfg push-external-registry --docker-username=unused --docker-password={{ hostvars['registry']['pushtoken'] }} --docker-email=unused --docker-server={{ central_registry_hostname }} -n {{ project_name }}"
+  command: "{{ oc }} secrets new-dockercfg push-external-registry --docker-username=unused --docker-password={{ hostvars['registry']['pushtoken'] }} --docker-email=unused --docker-server={{ central_registry_hostname }}"
   when: central_registry_secret|failed
 - name: Link docker push central registry secret
-  command: "{{ oc }} secrets link builder push-external-registry -n {{ project_name }}"
+  command: "{{ oc }} secrets link builder push-external-registry"
   when: central_registry_secret|failed
 - name: Check if push prod registry secret exists
   command: "{{ oc }} get secret push-prod-registry -n {{ project_name }}"


### PR DESCRIPTION
So that each cluster can specify its individual project name. This also
facilitates working with shared cluster(s) and separate projects.

This was already possible via override, but moving this in the example
templates should make it more obvious - at the cost of having to specify
a project name per cluster.

Taking the opportunity to consolidate '-n project_name' into the config
instead of each oc invocation