### PR TITLE
Fix missing REGISTRY_PROJECT reference in app pipeline

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -3,7 +3,7 @@
   hosts: all
   roles:
     - role: auth
-- name: Setup Jenkins
+- name: Setup Jenkins and registry push credentials
   hosts: dev
   roles:
     - role: jenkins

--- a/ansible/roles/jenkins/tasks/main.yml
+++ b/ansible/roles/jenkins/tasks/main.yml
@@ -46,6 +46,7 @@
     -p STAGE_URI=insecure://{{ hostvars['stage']['clusterhost'] }}
     -p DEV_PROJECT={{ hostvars['dev']['project_name'] }}
     -p STAGE_PROJECT={{ hostvars['stage']['project_name'] }}
+    -p REGISTRY_PROJECT={{ hostvars['registry']['project_name'] }}
     -p STAGE_SECRET_NAME={{ stage_api_secret_name }}
     | {{ oc }} apply --force=true -f -
 - name: Create release pipeline


### PR DESCRIPTION
The app pipeline was missing a `REGISTRY_PROJECT`, getting its default from the pipeline template (`lifecycle`).
