### PR TITLE
Always refresh the registry push secret

### DIFF
--- a/ansible/roles/pusher/tasks/main.yml
+++ b/ansible/roles/pusher/tasks/main.yml
@@ -1,11 +1,8 @@
 ---
-- name: Check if push central registry secret exists
-  command: "{{ oc }} get secret push-external-registry"
-  register: central_registry_secret
+- name: Remove push-to registry secret if it exists
+  command: "{{ oc }} get secret {{ registry_push_secret }}"
   ignore_errors: true
-- name: Docker push central registry secret
-  command: "{{ oc }} secrets new-dockercfg push-external-registry --docker-username=unused --docker-password={{ hostvars['registry']['pushtoken'] }} --docker-email=unused --docker-server={{ central_registry_hostname }}"
-  when: central_registry_secret|failed
-- name: Link docker push central registry secret
-  command: "{{ oc }} secrets link builder push-external-registry"
-  when: central_registry_secret|failed
+- name: Create secret to push to the central registry
+  command: "{{ oc }} secrets new-dockercfg {{ registry_push_secret }} --docker-username=unused --docker-password={{ hostvars['registry']['pushtoken'] }} --docker-email=unused --docker-server={{ central_registry_hostname }}"
+- name: Link docker push central registry secret to builder service account
+  command: "{{ oc }} secrets link builder {{ registry_push_secret }}"

--- a/ansible/roles/pusher/vars/main.yml
+++ b/ansible/roles/pusher/vars/main.yml
@@ -1,0 +1,2 @@
+---
+registry_push_secret: "push-external-registry"


### PR DESCRIPTION
Example use case: if you change the configuration and set another value for `central_registry_hostname`, the dockercfg inside the registry push secret has to be updated (the registry's hostname is part of that configuration).

Brute^WSimple fix here is to always recreate that secret... thoughts?
