### PR TITLE
Add viewer groups for the registry

### DIFF
--- a/ansible/group_vars/dev.yml.example
+++ b/ansible/group_vars/dev.yml.example
@@ -9,6 +9,8 @@ admin_users:
   - user2
 editor_users:
 viewer_users:
+viewer_groups:
 deprecated_admin_users:
 deprecated_editor_users:
 deprecated_viewer_users:
+deprecated_viewer_groups:

--- a/ansible/group_vars/prod.yml.example
+++ b/ansible/group_vars/prod.yml.example
@@ -10,8 +10,10 @@ editor_users:
 viewer_users:
   - user2@example.com
   - user3@example.com
+viewer_groups:
 deprecated_admin_users:
 deprecated_editor_users:
 deprecated_viewer_users:
+deprecated_viewer_groups:
 
 jenkins_automation_openshift_role: edit

--- a/ansible/group_vars/registry.yml.example
+++ b/ansible/group_vars/registry.yml.example
@@ -8,9 +8,22 @@ admin_users:
 editor_users:
   - user1
   - user2
+  # If the registry is the internal registry in the dev cluster, we need to
+  # grant access to the relevant service accounts from the dev project.
+  # This grants push access from dev builds to the registry:
+  #- system:serviceaccount:dev:builder
 viewer_users:
+viewer_groups:
+  # If the registry is the internal registry in the dev cluster, we need to
+  # grant access to the relevant service accounts from the dev project
+  # This grants pull access from dev/stage/prod to the registry:
+  # note that dev is required for the Jenkins job to monitor the imagestream
+  #- system:serviceaccounts:dev
+  #- system:serviceaccounts:stage
+  #- system:serviceaccounts:prod
 deprecated_admin_users:
 deprecated_editor_users:
 deprecated_viewer_users:
+deprecated_viewer_groups:
 
 jenkins_automation_openshift_role: edit

--- a/ansible/group_vars/stage.yml.example
+++ b/ansible/group_vars/stage.yml.example
@@ -11,6 +11,8 @@ admin_users:
   - user2
 editor_users:
 viewer_users:
+viewer_groups:
 deprecated_admin_users:
 deprecated_editor_users:
 deprecated_viewer_users:
+deprecated_viewer_groups:

--- a/ansible/roles/auth/tasks/main.yml
+++ b/ansible/roles/auth/tasks/main.yml
@@ -11,6 +11,10 @@
   command: "{{ oc }} policy add-role-to-user {{ project_registry_viewer_role}} {{ item }}"
   with_items: "{{ viewer_users }}"
   when: viewer_users
+- name: Add viewer groups
+  command: "{{ oc }} policy add-role-to-group {{ project_registry_viewer_role}} {{ item }}"
+  with_items: "{{ viewer_groups }}"
+  when: viewer_groups
 
 - name: Remove admin users
   command: "{{ oc }} policy remove-role-from-user {{ project_admin_role}} {{ item }}"
@@ -24,6 +28,10 @@
   command: "{{ oc }} policy remove-role-from-user {{ project_registry_viewer_role}} {{ item }}"
   with_items: "{{ deprecated_viewer_users }}"
   when: deprecated_viewer_users
+- name: Remove viewer groups
+  command: "{{ oc }} policy remove-role-from-group {{ project_registry_viewer_role}} {{ item }}"
+  with_items: "{{ deprecated_viewer_groups }}"
+  when: deprecated_viewer_groups
 
 - name: Check if Jenkins serviceaccount exists
   command: "{{ oc }} get sa {{ jenkins_serviceaccount_name }}"


### PR DESCRIPTION
This adds `viewer_groups` and corresponding `add-role-to-group` using the same viewer role as the `viewer_users`.

This is useful in sigle-cluster deployments where the dev/stage/prod projects need access to the registry.

