### PR TITLE
Move some variables from group/host vars to role vars/defaults

### DIFF
--- a/ansible/group_vars/all.yml.example
+++ b/ansible/group_vars/all.yml.example
@@ -10,9 +10,6 @@ app_template_path: app/openshift/nodejs-mongodb-persistent.json
 # app_name is used to name build and deployment configurations
 app_name: nodejs-mongo-persistent
 app_base_tag: nodejs:6
-# name of the generated ImageStreams
-imagestream_name: "{{ app_name }}"
-imagestream_latest_tag: latest
 
 # ----------------------
 # Environment parameters
@@ -22,24 +19,12 @@ imagestream_latest_tag: latest
 # You can add a port if needed, e.g. registry.example.com:5000
 central_registry_hostname: registry.example.com
 
-jenkins_serviceaccount_name: jenkins
-jenkins_volume_size: 2Gi
-registry_api_secret_name: registry-api
-stage_api_secret_name: stage-api
-prod_api_secret_name: prod-api
-
-# Name of the service account that these playbooks create in each project to
-# control access. This is used both by playbooks themselves and by some of the
-# objects created (e.g. for the Jenkins job in the Dev project to monitor
-# ImageStreams in Stage)
-token_name: ansible
-
-# The names of the OpenShift roles to assign to project roles.
-# These would rarely need to be adjusted.
-project_admin_role: admin
-project_editor_role: edit
-project_viewer_role: view
-project_registry_viewer_role: registry-viewer
+# Wether to validate TLS/SSL certs involved in communications with OpenShift
+# and/or registry. Note: setting this to False may not be enough: this only
+# affects interactions managed by these playbooks, but image push/pull is
+# handled by the nodes, so you might have to adjust container runtime
+# configuration there
+validate_certs: True
 
 # --------------
 # Job parameters
@@ -47,7 +32,6 @@ project_registry_viewer_role: registry-viewer
 notify_email_list: devops@example.com
 notify_email_from: jenkins@example.com
 notify_email_replyto: noreply@example.com
-validate_certs: True
 
 # --------------------------------
 # OpenShift client command options

--- a/ansible/group_vars/prod.yml.example
+++ b/ansible/group_vars/prod.yml.example
@@ -19,5 +19,3 @@ deprecated_admin_users:
 deprecated_editor_users:
 deprecated_viewer_users:
 deprecated_viewer_groups:
-
-jenkins_automation_openshift_role: edit

--- a/ansible/group_vars/registry.yml.example
+++ b/ansible/group_vars/registry.yml.example
@@ -34,5 +34,3 @@ deprecated_admin_users:
 deprecated_editor_users:
 deprecated_viewer_users:
 deprecated_viewer_groups:
-
-jenkins_automation_openshift_role: edit

--- a/ansible/group_vars/stage.yml.example
+++ b/ansible/group_vars/stage.yml.example
@@ -6,8 +6,6 @@ project_name: stage
 project_display_name: "Stage - Software lifecycle"
 project_description: "Stage - Software Development Lifecycle (SDLC)"
 
-jenkins_automation_openshift_role: edit
-
 admin_users:
 #  - user1
 #  - user2

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -2,6 +2,8 @@
 
 - name: Project Bootstrap
   hosts: all
+  vars:
+    ansible_serviceaccount_name: ansible
   tasks:
     - name: Get User Token
       uri:
@@ -19,19 +21,25 @@
       when: token is undefined
 
     - name: Create Project
-      command: "{{ oc }} --config=/dev/null new-project {{ project_name }} --display-name='{{ project_display_name }}' --description='{{ project_description }}'"
+      command: >-
+        {{ oc }} new-project {{ project_name }}
+        --display-name='{{ project_display_name }}'
+        --description='{{ project_description }}'
       ignore_errors: True
 
     - name: Create service account
-      command: "{{ oc }} --config=/dev/null create serviceaccount {{ token_name }} -n {{ project_name }}"
+      command: >-
+        {{ oc }} create serviceaccount {{ ansible_serviceaccount_name }}
       ignore_errors: True
 
     - name: Add role to user
-      command: "{{ oc }} --config=/dev/null policy add-role-to-user admin -z {{ token_name }} -n {{ project_name }}"
+      command: >-
+        {{ oc }}
+        policy add-role-to-user admin -z {{ ansible_serviceaccount_name }}
       ignore_errors: True
 
     - name: Get Token
-      command: "{{ oc }} --config=/dev/null sa get-token {{ token_name }} -n {{ project_name }}"
+      command: "{{ oc }} sa get-token {{ ansible_serviceaccount_name }}"
       register: new_token
 
     - name: New Token

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -22,24 +22,27 @@
 
     - name: Create Project
       command: >-
-        {{ oc }} new-project {{ project_name }}
+        {{ oc }} --config=/dev/null new-project {{ project_name }}
         --display-name='{{ project_display_name }}'
         --description='{{ project_description }}'
       ignore_errors: True
 
     - name: Create service account
       command: >-
-        {{ oc }} create serviceaccount {{ ansible_serviceaccount_name }}
+        {{ oc }} --config=/dev/null
+        create serviceaccount {{ ansible_serviceaccount_name }}
       ignore_errors: True
 
     - name: Add role to user
       command: >-
-        {{ oc }}
+        {{ oc }} --config=/dev/null
         policy add-role-to-user admin -z {{ ansible_serviceaccount_name }}
       ignore_errors: True
 
     - name: Get Token
-      command: "{{ oc }} sa get-token {{ ansible_serviceaccount_name }}"
+      command: >-
+        {{ oc }} --config=/dev/null
+        sa get-token {{ ansible_serviceaccount_name }}
       register: new_token
 
     - name: New Token

--- a/ansible/roles/auth/vars/main.yml
+++ b/ansible/roles/auth/vars/main.yml
@@ -1,0 +1,14 @@
+---
+# The name of the ServiceAccount that is created in the different projects to
+# allow Jenkins job to access them
+jenkins_serviceaccount_name: jenkins
+# The OpenShift role that will be assigned to the jenkins ServiceAccount in
+# each project. Note that you can override this per environment in the
+# environment's respective file under group_vars
+jenkins_automation_openshift_role: edit
+# project_*_role are the names of the OpenShift roles that will be used to grant
+# the respective privileges. These should rarely need adjustment, unless the
+# OpenShift clusters have had their default roles customized.
+project_admin_role: admin
+project_editor_role: edit
+project_registry_viewer_role: registry-viewer

--- a/ansible/roles/jenkins/defaults/main.yml
+++ b/ansible/roles/jenkins/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# name of the generated ImageStreams
+imagestream_name: "{{ app_name }}"
+imagestream_latest_tag: latest

--- a/ansible/roles/jenkins/vars/main.yml
+++ b/ansible/roles/jenkins/vars/main.yml
@@ -1,3 +1,14 @@
 ---
-
+# The deployed Jenkins instance uses a PersistentVolumeClaim. This var
+# specifies the requested size of the PVC
+jenkins_volume_size: 2Gi
+# The {registry,stage,prod}_api_secret_names set the names of the secrets that
+# are created to store tokens to be sync'd to Jenkins credentials to allow jobs
+# (which run in the dev environment) to access the projects/clusters of the
+# other environments
+registry_api_secret_name: registry-api
+stage_api_secret_name: stage-api
+prod_api_secret_name: prod-api
+# openshift_protocol is the URI protocol to connect to clusters.
+# Here we make it depend on the 'validate_certs' variable
 openshift_protocol: "{% if validate_certs %}https{% else %}insecure{% endif %}"


### PR DESCRIPTION
Some variables are less prone to customization, and they make the global host/group variable configuration confusing.

This moves them to role vars/defaults, where they still can be overriden the ansible way (e.g. --extra-vars) if needed.

One of the vars (`project_viewer_role`) was actually unused and has been removed, and `token_name` has been renamed to `ansible_serviceaccount_name` (for consistency with `jenkins_serviceaccount_name`) and specified now directly in the bootstrap play, the only place where it's referenced.