### PR TITLE
Do not open up registry to anon pulls

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -42,9 +42,3 @@
     - prod
   roles:
     - role: puller
-
-- name: Open up registry to anon pulls
-  hosts: registry
-  tasks:
-    - name: Open registry to anonymous pulls
-      command: "{{ oc }} policy add-role-to-group registry-viewer system:unauthenticated"


### PR DESCRIPTION
I'm not sure why this was added, but it doesn't seem to be necessary for the refarch itself.

Any objections @aweiteka @jcpowermac ?