### PR TITLE
Allow override of user input via build parameters

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -44,20 +44,35 @@ pipeline {
             }
             steps {
                 script {
-                    def userInput
-                    timeout(2) {
-                        userInput = input(message: "Enter build to release as version ${env.RELEASE_VERSION}", parameters: [string(defaultValue: '', description: 'Build version image tag, e.g. 1.3-8', name: 'buildVersion')])
+                    /** Set the Production Tag via a build parameter
+                     *
+                     * The RELEASE_VERSION_TAG optional parameter allows to pre-set
+                     * which image tag to promote to production. If unset, the user
+                     * will be prompted.
+                     */
+                    def releaseVersionTag
+                    if (params.containsKey('RELEASE_VERSION_TAG')) {
+                        releaseVersionTag = params.RELEASE_VERSION_TAG
+                    } else {
+                        timeout(2) {
+                            releaseVersionTag = input(
+                                message: "Enter build to release as version ${env.RELEASE_VERSION}",
+                                parameters: [ string(defaultValue: '',
+                                                     description: 'Build version image tag, e.g. 1.3-8',
+                                                     name: 'buildVersion')
+                                ])
+                        }
                     }
-                    echo "Releasing build ${userInput} as ${env.RELEASE_VERSION}"
+                    echo "Releasing build ${releaseVersionTag} as ${env.RELEASE_VERSION}"
 
                     /* Connect to the registry cluster and project
                      * Make sure the image tag exists if not abort the job
                      */
                     openshift.withCluster("${params.OPENSHIFT_REGISTRY_URI}", env.REGISTRY_PSW) {
                         openshift.withProject("${params.REGISTRY_PROJECT}") {
-                            def istagSelector = openshift.selector("istag", "${params.IMAGE_STREAM_NAME}:${userInput}")
+                            def istagSelector = openshift.selector("istag", "${params.IMAGE_STREAM_NAME}:${releaseVersionTag}")
                             if (!istagSelector.exists()) {
-                                echo "Imagestream tag ${userInput} does not exist in registry"
+                                echo "Imagestream tag ${releaseVersionTag} does not exist in registry"
                                 currentBuild.result = 'ABORTED'
                             }
                         }
@@ -68,9 +83,9 @@ pipeline {
                      */
                     openshift.withCluster("${params.OPENSHIFT_REGISTRY_URI}", env.REGISTRY_PSW) {
                         openshift.withProject("${params.REGISTRY_PROJECT}") {
-                            openshift.tag("${openshift.project()}/${params.IMAGE_STREAM_NAME}:${userInput}",
+                            openshift.tag("${openshift.project()}/${params.IMAGE_STREAM_NAME}:${releaseVersionTag}",
                                     "${openshift.project()}/${params.IMAGE_STREAM_NAME}:${env.RELEASE_VERSION}")
-                            openshift.tag("${openshift.project()}/${params.IMAGE_STREAM_NAME}:${userInput}",
+                            openshift.tag("${openshift.project()}/${params.IMAGE_STREAM_NAME}:${releaseVersionTag}",
                                     "${openshift.project()}/${params.IMAGE_STREAM_NAME}:latest")
                         }
                     }

--- a/ansible/roles/jenkins/files/base-image-pipeline.yaml
+++ b/ansible/roles/jenkins/files/base-image-pipeline.yaml
@@ -26,7 +26,6 @@ objects:
                     appName = "${APP_NAME}"
                     appBcName = "${APP_BC}"
                     appNamespace = "${APP_NAMESPACE}"
-                    appPipeline = "${APP_PIPELINE}"
                 }
                 stages {
                     stage('Check base image version') {
@@ -88,9 +87,8 @@ objects:
                                     }
                                 }
                                 if (rebuild == 'true' && goAhead != 'null') {
-                                    echo "Starting a build of ${appPipeline}"
-                                    build job: "${appPipeline}", wait: false
-                                    //echo "rebuilding job ${appPipeline}"
+                                    echo "Starting a build of ${appBcName}"
+                                    build job: "${appBcName}", wait: false
                                 }
                             }
                         }
@@ -154,8 +152,3 @@ parameters:
   name: NOTIFY_EMAIL_REPLYTO
   required: true
   value: "noreply@example.com"
-- description: Application pipeline name
-  displayName: Application pipeline name, e.g. 'jenkins-lifecycle'
-  name: APP_PIPELINE
-  required: true
-  value: "lifecycle-jenkins-lifecycle"

--- a/ansible/roles/jenkins/files/base-image-pipeline.yaml
+++ b/ansible/roles/jenkins/files/base-image-pipeline.yaml
@@ -69,13 +69,26 @@ objects:
                     stage('Upgrade prompt') {
                         steps {
                             script {
+                                def goAhead
                                 if (rebuild == 'true') {
-                                    timeout(1) {
-                                        userInput = input(
-                                            id: 'userInput', message: 'Upgrade base image?')
+                                    /*
+                                    * Check if the developer wants an updated build using the new
+                                    * base image. The 'input' function will wait for an interactive
+                                    * answer for 1 minute. If the UPGRADE_WIHTOUT_ASKING parameter
+                                    * is set to any value, the build will be triggered automatically
+                                    * without the interactive check.
+                                    */
+                                    if (params.containsKey('UPGRADE_WITHOUT_ASKING')) {
+                                        goAhead = true
+                                    } else {
+                                        timeout(1) {
+                                            goAhead = input(
+                                                id: 'userInput', message: 'Upgrade base image?')
+                                        }
                                     }
                                 }
-                                if (rebuild == 'true' && userInput != 'null') {
+                                if (rebuild == 'true' && goAhead != 'null') {
+                                    echo "Starting a build of ${appPipeline}"
                                     build job: "${appPipeline}", wait: false
                                     //echo "rebuilding job ${appPipeline}"
                                 }

--- a/ansible/roles/jenkins/tasks/main.yml
+++ b/ansible/roles/jenkins/tasks/main.yml
@@ -113,7 +113,6 @@
     -p APP_BC={{ app_name }}
     -p APP_NAME={{ app_name }}
     -p BASE_IMAGE_TAG={{ app_base_tag }}
-    -p APP_PIPELINE={{ project_name}}-{{ app_name }}
     -p APP_NAMESPACE={{ project_name }}
     -p NOTIFY_EMAIL_LIST={{ notify_email_list }}
     -p NOTIFY_EMAIL_FROM={{ notify_email_from }}


### PR DESCRIPTION
Following Justin's feedback: introducing two (optional) build parameters for the pipelines that prompt the user for input: the parameters override that manual input, enabling full automation without user intervention.

We've discussed pros/cons and for now the agreement was that it was a good idea to keep the explicit input as a safety / awareness check: before rolling an image to production, it's not too bad to have to explicitly input the image version to roll out. In other words: the default behaviour (as documented in the refarch doc) does not change.

If someone wants to specify the version to release for the release pipeline using these parameters they can do:

    oc set env bc/release-pipeline RELEASE_VERSION_TAG=1.0-1

and then the release pipeline will deploy image tag *1.0-1* to production without asking for input.

For the base-image pipelines, setting `UPGRADE_WITHOUT_ASKING` to any value will avoid the interactive confirmation prompt:

     oc set env bc/jenkins-base-image UPGRADE_WITHOUT_ASKING=yes

While testing these base image pipelines I hit some problems... initially it seemed that the parameters being referenced by the pipelines were incorrect, resulting in this type of error upon upgrade approval:

    ERROR: No item named lifecycle-jenkins-lifecycle found

The third commit in this PR is an attempt to fix that problem. However, it now shows a different error:

    No item named jenkins-custom found

@jcpowermac could you take a look?
