### PR TITLE
Workaround for v3.7 dockercfg secret issue

### DIFF
--- a/ansible/group_vars/all.yml.example
+++ b/ansible/group_vars/all.yml.example
@@ -36,8 +36,31 @@ notify_email_replyto: noreply@example.com
 # --------------------------------
 # OpenShift client command options
 # --------------------------------
+# URL to location of openshift origin client
+oc_url: "https://github.com/openshift/origin/releases/download/v3.6.1/openshift-origin-client-tools-v3.6.1-008f2d5-linux-64bit.tar.gz"
+# Destination location of the oc binary
+oc_extract_dest: "{{ ansible_user_dir }}/"
+# Path to openshift client
+oc_path: "/usr/bin/oc"
+
+# Disable logging of openshift client command/shell
+# to hide tokens.
+# *NOTE*: Set to False if debugging is required.
+oc_no_log: True
+
+# Client issue creating dockercfg secrets introduced
+# in v3.7.  This workaround downloads the Origin v3.6.1
+# as a temporary resolution to the issue.  See more information
+# in the links below.
+#
+# https://github.com/openshift/origin/pull/18062
+# https://bugzilla.redhat.com/show_bug.cgi?id=1531511
+# https://bugzilla.redhat.com/show_bug.cgi?id=1476330
+enable_dockercfg_workaround: True
+
+#
 # This is how the "oc" client will be invoked.
 # The token/clusterhost/project_name are set in vars for each environment
 oc: >-
-  oc {% if not validate_certs %}--insecure-skip-tls-verify{% endif %}
+  {{ oc_path }} {% if not validate_certs %}--insecure-skip-tls-verify{% endif %}
   --token={{ token }} --server=https://{{ clusterhost }} -n {{ project_name }}

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -1,8 +1,44 @@
 ---
-
 - name: Project Bootstrap
   hosts: all
   tasks:
+
+    - name: Locate oc client
+      find:
+        paths: "{{ ansible_env['PATH'].split(':') }}"
+        patterns: 'oc'
+      register: oc_cmd
+
+    - set_fact:
+        oc_path: "{{ oc_cmd.files[0]['path'] }}"
+      when: oc_cmd.matched != 0
+
+    - set_fact:
+        enable_dockercfg_workaround: True
+      when: oc_cmd.matched == 0
+
+    - name: Bugzilla 1531511, 1476330, Github 18062 Workaround
+      block:
+        - name: Download Origin v3.6.1 client
+          get_url:
+            url: "{{ oc_url }}"
+            dest: "{{ oc_extract_dest }}/oc-client.tar"
+
+        - name: Extract oc
+          unarchive:
+            src: "{{ oc_extract_dest }}/oc-client.tar"
+            dest: "{{ oc_extract_dest }}"
+            extra_opts:
+              - "--strip-components=1"
+
+      delegate_to: localhost
+      when: enable_dockercfg_workaround
+      run_once: True
+
+    - set_fact:
+        oc_path: "{{ oc_extract_dest }}/oc"
+      when: enable_dockercfg_workaround
+
     - name: Get User Token
       uri:
         url: "https://{{ clusterhost }}/oauth/authorize?response_type=token&client_id=openshift-challenging-client"
@@ -24,6 +60,7 @@
         --display-name='{{ project_display_name }}'
         --description='{{ project_description }}'
       ignore_errors: True
+      no_log: "{{ oc_no_log }}"
 
 - name: Configure project authorization
   hosts: all

--- a/ansible/roles/auth/tasks/main.yml
+++ b/ansible/roles/auth/tasks/main.yml
@@ -3,53 +3,63 @@
   command: "{{ oc }} policy add-role-to-user {{ project_admin_role}} {{ item }}"
   with_items: "{{ admin_users }}"
   when: admin_users
+  no_log: "{{ oc_no_log }}"
 
 - name: Add editor users
   command: "{{ oc }} policy add-role-to-user {{ project_editor_role}} {{ item }}"
   with_items: "{{ editor_users }}"
   when: editor_users
+  no_log: "{{ oc_no_log }}"
 
 - name: Add viewer users
   command: "{{ oc }} policy add-role-to-user {{ project_registry_viewer_role}} {{ item }}"
   with_items: "{{ viewer_users }}"
   when: viewer_users
+  no_log: "{{ oc_no_log }}"
 
 - name: Add viewer groups
   command: "{{ oc }} policy add-role-to-group {{ project_registry_viewer_role}} {{ item }}"
   with_items: "{{ viewer_groups }}"
   when: viewer_groups
+  no_log: "{{ oc_no_log }}"
 
 - name: Remove admin users
   command: "{{ oc }} policy remove-role-from-user {{ project_admin_role}} {{ item }}"
   with_items: "{{ deprecated_admin_users }}"
   when: deprecated_admin_users
+  no_log: "{{ oc_no_log }}"
 
 - name: Remove editor users
   command: "{{ oc }} policy remove-role-from-user {{ project_editor_role}} {{ item }}"
   with_items: "{{ deprecated_editor_users }}"
   when: deprecated_editor_users
+  no_log: "{{ oc_no_log }}"
 
 - name: Remove viewer users
   command: "{{ oc }} policy remove-role-from-user {{ project_registry_viewer_role}} {{ item }}"
   with_items: "{{ deprecated_viewer_users }}"
   when: deprecated_viewer_users
+  no_log: "{{ oc_no_log }}"
 
 - name: Remove viewer groups
   command: "{{ oc }} policy remove-role-from-group {{ project_registry_viewer_role}} {{ item }}"
   with_items: "{{ deprecated_viewer_groups }}"
   when: deprecated_viewer_groups
+  no_log: "{{ oc_no_log }}"
 
 - name: Check if Jenkins serviceaccount exists
   command: "{{ oc }} get sa {{ jenkins_serviceaccount_name }}"
   register: jenkins_sa_exists
   ignore_errors: true
   when: jenkins_automation_openshift_role is defined
+  no_log: "{{ oc_no_log }}"
 
 - name: Create Jenkins serviceaccount
   command: "{{ oc }} create serviceaccount {{ jenkins_serviceaccount_name }}"
   when:
     - jenkins_sa_exists|failed
     - jenkins_automation_openshift_role is defined
+  no_log: "{{ oc_no_log }}"
 
 - name: Assign role to Jenkins serviceaccount
   command: >-
@@ -58,24 +68,30 @@
   when:
     - jenkins_sa_exists|failed
     - jenkins_automation_openshift_role is defined
+  no_log: "{{ oc_no_log }}"
 
 - name: Get Jenkins token value
   command: "{{ oc }} sa get-token {{ jenkins_serviceaccount_name }}"
   register: jenkinstoken
   when: jenkins_automation_openshift_role is defined
+  no_log: "{{ oc_no_log }}"
 
 - set_fact:
     jenkinstoken: "{{ jenkinstoken.stdout }}"
   when: jenkins_automation_openshift_role is defined
+  no_log: "{{ oc_no_log }}"
 
 - name: Get registry push token value
   command: "{{ oc }} sa get-token builder"
   register: forpush
+  no_log: "{{ oc_no_log }}"
 
 - name: Get pull token value
   command: "{{ oc }} sa get-token deployer"
   register: forpull
+  no_log: "{{ oc_no_log }}"
 
 - set_fact:
     pushtoken: "{{ forpush.stdout }}"
     pulltoken: "{{ forpull.stdout }}"
+  no_log: "{{ oc_no_log }}"

--- a/ansible/roles/jenkins/tasks/main.yml
+++ b/ansible/roles/jenkins/tasks/main.yml
@@ -4,36 +4,42 @@
   when: registry_api_secret_name is defined
   register: registry_api_secret_exists
   ignore_errors: true
+  no_log: "{{ oc_no_log }}"
 
 - name: Check if {{ stage_api_secret_name }} exists
   command: "{{ oc }} get secret {{ stage_api_secret_name }}"
   when: stage_api_secret_name is defined
   register: stage_api_secret_exists
   ignore_errors: true
+  no_log: "{{ oc_no_log }}"
 
 - name: Check if {{ prod_api_secret_name }} exists
   command: "{{ oc }} get secret {{ prod_api_secret_name }}"
   when: prod_api_secret_name is defined
   register: prod_api_secret_exists
   ignore_errors: true
+  no_log: "{{ oc_no_log }}"
 
 - name: Create secret {{ registry_api_secret_name }}
   command: "{{ oc }} secret new-basicauth {{ registry_api_secret_name }} --password {{ hostvars['registry-1']['jenkinstoken'] }}"
   when:
     - registry_api_secret_exists|failed
     - hostvars['registry-1']['jenkinstoken'] is defined
+  no_log: "{{ oc_no_log }}"
 
 - name: Create secret {{ stage_api_secret_name }}
   command: "{{ oc }} secret new-basicauth {{ stage_api_secret_name }} --password {{ hostvars['stage-1']['jenkinstoken'] }}"
   when:
     - stage_api_secret_exists|failed
     - hostvars['stage-1']['jenkinstoken'] is defined
+  no_log: "{{ oc_no_log }}"
 
 - name: Create secret {{ prod_api_secret_name }}
   command: "{{ oc }} secret new-basicauth {{ prod_api_secret_name }} --password {{ hostvars['prod-1']['jenkinstoken'] }}"
   when:
     - prod_api_secret_exists|failed
     - hostvars['prod-1']['jenkinstoken'] is defined
+  no_log: "{{ oc_no_log }}"
 
 - name: Create custom Jenkins source-to-image build
   shell: >-
@@ -41,6 +47,7 @@
     --param SOURCE_REPOSITORY_URL={{ source_repo_url }}
     --param SOURCE_REPOSITORY_REF={{ source_repo_branch }}
     | {{ oc }} apply --force=true -f -
+  no_log: "{{ oc_no_log }}"
 
 - name: Create Jenkins app
   shell: >-
@@ -50,6 +57,7 @@
     --param MEMORY_LIMIT=2Gi
     --param JENKINS_IMAGE_STREAM_TAG=jenkins-custom:latest
     | {{ oc }} apply -f -
+  no_log: "{{ oc_no_log }}"
 
 - name: Create application pipeline
   shell: >-
@@ -68,6 +76,7 @@
     -p REGISTRY_PROJECT={{ hostvars['registry-1']['project_name'] }}
     -p STAGE_SECRET_NAME={{ stage_api_secret_name }}
     | {{ oc }} apply --force=true -f -
+  no_log: "{{ oc_no_log }}"
 
 - name: Create release pipeline
   shell: >-
@@ -88,6 +97,7 @@
     -p NOTIFY_EMAIL_FROM={{ notify_email_from }}
     -p NOTIFY_EMAIL_REPLYTO={{ notify_email_replyto }}
     | {{ oc }} apply --force=true -f - -n {{ project_name }}
+  no_log: "{{ oc_no_log }}"
 
 - name: Create Jenkins master pipeline
   shell: >-
@@ -95,6 +105,7 @@
     -p SOURCE_REPOSITORY_URL={{ source_repo_url }}
     -p SOURCE_REPOSITORY_REF={{ source_repo_branch }}
     | {{ oc }} apply --force=true -f -
+  no_log: "{{ oc_no_log }}"
 
 - name: Create Jenkins base image pipeline
   # Most of the defaults in the template are already set to match Jenkins
@@ -105,6 +116,7 @@
     -p NOTIFY_EMAIL_FROM={{ notify_email_from }}
     -p NOTIFY_EMAIL_REPLYTO={{ notify_email_replyto }}
     | {{ oc }} apply --force=true -f -
+  no_log: "{{ oc_no_log }}"
 
 - name: Create application base image pipeline
   # Using the same template but changing some parmeters to match the app
@@ -118,17 +130,21 @@
     -p NOTIFY_EMAIL_FROM={{ notify_email_from }}
     -p NOTIFY_EMAIL_REPLYTO={{ notify_email_replyto }}
     | {{ oc }} apply --force=true -f -
+  no_log: "{{ oc_no_log }}"
 
 - name: Get last jenkins-custom build number
   command: "{{ oc }} get bc jenkins-custom --template '{{ '{{' }} .status.lastVersion {{ '}}' }}'"
   register: jenkins_custom_build_number
+  no_log: "{{ oc_no_log }}"
 
 - name: Get last jenkins-custom build status
   command: "{{ oc }} get build jenkins-custom-{{ jenkins_custom_build_number.stdout }} --template '{{ '{{' }} .status.phase {{ '}}' }}'"
   register: jenkins_custom_build_status
   ignore_errors: true
+  no_log: "{{ oc_no_log }}"
 
 - name: Start jenkins-custom build
   command: "{{ oc }} start-build jenkins-custom"
   when: jenkins_custom_build_status.stdout != 'Running'
   ignore_errors: true
+  no_log: "{{ oc_no_log }}"

--- a/ansible/roles/puller/tasks/main.yml
+++ b/ansible/roles/puller/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Remove pull-from central registry secret if it exists
   command: "{{ oc }} delete secret {{ registry_pull_secret }}"
   ignore_errors: true
+  no_log: "{{ oc_no_log }}"
 
 - name: Create secret to pull from the central registry
   command: >-
@@ -9,6 +10,8 @@
     --docker-username=unused
     --docker-password={{ registry_pull_token }}
     --docker-email=unused --docker-server={{ central_registry_hostname }}
+  no_log: "{{ oc_no_log }}"
 
 - name: Link docker pull registry secret to the default service account
   command: "{{ oc }} secrets link default {{ registry_pull_secret }} --for=pull"
+  no_log: "{{ oc_no_log }}"

--- a/ansible/roles/pusher/tasks/main.yml
+++ b/ansible/roles/pusher/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Remove push-to registry secret if it exists
   command: "{{ oc }} delete secret {{ registry_push_secret }}"
   ignore_errors: true
+  no_log: "{{ oc_no_log }}"
 
 - name: Create secret to push to the central registry
   command: >-
@@ -9,6 +10,8 @@
     --docker-password={{ registry_push_token }}
     --docker-username=unused --docker-email=unused
     --docker-server={{ central_registry_hostname }}
+  no_log: "{{ oc_no_log }}"
 
 - name: Link docker push central registry secret to builder service account
   command: "{{ oc }} secrets link builder {{ registry_push_secret }}"
+  no_log: "{{ oc_no_log }}"


### PR DESCRIPTION
This PR includes the ability to download the origin v3.6.1 which
will correctly create a dockercfg secret.

